### PR TITLE
Add manual deploy workflow via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to Server
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            cd /opt/audiobook-maker
+            git pull origin main
+            pip install -r requirements.txt
+            sudo systemctl restart audiobook-maker


### PR DESCRIPTION
## Summary
- Adds a **manual deploy** workflow triggered from the GitHub Actions UI (`workflow_dispatch`)
- Connects to the VPS via SSH, pulls latest code, installs dependencies and restarts the `audiobook-maker` systemd service

## How to use
1. Go to **Actions** tab → **Deploy to Server** workflow
2. Click **Run workflow** → **Run workflow**
3. The deploy will execute automatically on the server

## Prerequisites
Three secrets must be configured in **Settings → Secrets → Actions**:
- `SERVER_HOST` — Server IP or hostname
- `SERVER_USER` — SSH username
- `SERVER_SSH_KEY` — SSH private key

🤖 Generated with [Claude Code](https://claude.com/claude-code)